### PR TITLE
Add persistent dark mode and font size settings via settings page

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,17 +1,20 @@
+// Modified by: Mohammad Hoque (6/2/25)
+// Description: Applies global theme and font size preferences using <body> dataset attributes
+
 import Head from 'next/head'
 import '@/styles/globals.css'
-//import 'antd/dist/antd.css'
 import type { AppProps } from 'next/app'
-import '../styles/globals.css'
-import '@/styles/globals.css'
-
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 
 export default function App({ Component, pageProps }: AppProps) {
+  // On first render, apply saved theme and font size to <body> for global styling
   useEffect(() => {
-    const storedFont = typeof window !== 'undefined' && localStorage.getItem('fontSize')
-    if (storedFont) {
+    if (typeof window !== 'undefined') {
+      const storedFont = localStorage.getItem('fontSize') || 'regular'
+      const storedTheme = localStorage.getItem('theme') || 'default'
+
       document.body.dataset.fontsize = storedFont
+      document.body.dataset.theme = storedTheme
     }
   }, [])
 

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -6,6 +6,10 @@
 // Date: 06/01/2025
 // Reformatted the code to simplify project's coding style.
 
+// Edited by: Mohammad Hoque
+// Date: 06/02/2025
+// Enhancements: Added persistent theme and font settings, synced with <body> attributes, enabled dark mode UI styles dynamically
+
 import { useState, useEffect } from 'react'
 import { Button, Select, Input, DatePicker, message } from 'antd'
 import { ArrowLeftOutlined } from '@ant-design/icons'
@@ -20,15 +24,34 @@ const { Option } = Select
 countries.registerLocale(enLocale)
 const allCountries = Object.values(countries.getNames('en'))
 
-// Settings component with user options for Methuselah
 export default function Settings() {
   const [fontSize, setFontSize] = useState('regular')
   const [theme, setTheme] = useState('default')
-  // const [country, setCountry] = useState('United States')
   const [name, setName] = useState('')
   const [birthday, setBirthday] = useState<moment.Moment | null>(null)
 
-  // Updates document body and saves to LOCAL storage for font size change
+  // Added by: Mohammad Hoque - 06/02/2025
+  // Restores user settings on component mount (persistent state)
+  useEffect(() => {
+    const saved = localStorage.getItem('userSettings')
+    if (saved) {
+      const settings = JSON.parse(saved)
+      setName(settings.name || '')
+      setFontSize(settings.fontSize || 'regular')
+      setTheme(settings.theme || 'default')
+      setBirthday(settings.birthday ? moment(settings.birthday) : null)
+    }
+  }, [])
+
+  // Added by: Mohammad Hoque - 06/02/2025
+  // Sync selected theme to <body> attribute for global dark mode styling
+  useEffect(() => {
+    document.body.dataset.theme = theme
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  // Added by: Mohammad Hoque - 06/02/2025
+  // Sync selected font size to <body> attribute
   useEffect(() => {
     document.body.dataset.fontsize = fontSize
     localStorage.setItem('fontSize', fontSize)
@@ -43,6 +66,66 @@ export default function Settings() {
     }
     localStorage.setItem('userSettings', JSON.stringify(settings))
     message.success('Settings saved!')
+  }
+
+  // Modified by: Mohammad Hoque - 06/02/2025
+  // Dynamically apply dark or light styles using ternary conditions
+  const styles: { [key: string]: React.CSSProperties } = {
+    page: {
+      minHeight: '100vh',
+      backgroundColor: theme === 'dark' ? '#1D1E2C' : '#F1F1EB',
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: '40px'
+    },
+    card: {
+      backgroundColor: theme === 'dark' ? '#27293d' : '#A0B6AA',
+      borderRadius: '2rem',
+      border: '3px solid',
+      borderColor: theme === 'dark' ? '#318182' : '#000000',
+      padding: '40px',
+      width: '100%',
+      maxWidth: '480px',
+      boxShadow: '0 4px 12px rgba(0,0,0,0.1)'
+    },
+    backButton: {
+      marginBottom: '24px',
+      backgroundColor: theme === 'dark' ? '#318182' : '#203625',
+      color: 'white',
+      borderColor: theme === 'dark' ? '#318182' : '#203625',
+      borderRadius: '9999px'
+    },
+    header: {
+      textAlign: 'center',
+      fontSize: '24px',
+      marginBottom: '32px',
+      color: theme === 'dark' ? '#F1F1EA' : '#1D1E2C'
+    },
+    form: {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '20px'
+    },
+    label: {
+      fontWeight: 'bold',
+      marginBottom: '4px',
+      color: theme === 'dark' ? '#F1F1EA' : 'inherit'
+    },
+    input: {
+      width: '100%',
+      borderRadius: '12px',
+      backgroundColor: theme === 'dark' ? '#1D1E2C' : undefined,
+      color: theme === 'dark' ? '#F1F1EA' : undefined,
+      borderColor: theme === 'dark' ? '#318182' : undefined
+    },
+    saveButton: {
+      marginTop: '16px',
+      backgroundColor: theme === 'dark' ? '#318182' : '#203625',
+      color: 'white',
+      borderColor: theme === 'dark' ? '#318182' : '#203625',
+      borderRadius: '9999px'
+    }
   }
 
   return (
@@ -73,29 +156,12 @@ export default function Settings() {
             />
           </div>
 
-          {/* Country Field */}
-          {/* <div>
-            <div style={styles.label}>Country:</div>
-            <Select
-              showSearch
-              value={country}
-              onChange={(val) => setCountry(val)}
-              style={styles.input}
-              placeholder="Select your country"
-            >
-              {allCountries.map((c, i) => (
-                <Option key={i} value={c}>
-                  {c}
-                </Option>
-              ))}
-            </Select>
-          </div> */}
-
           {/* Theme Field */}
           <div>
             <div style={styles.label}>Theme:</div>
             <Select value={theme} onChange={(val) => setTheme(val)} style={styles.input}>
-              <Option value="default">Default</Option>
+              <Option value="default">Light</Option>
+              <Option value="dark">Dark</Option>
             </Select>
           </div>
 
@@ -109,7 +175,31 @@ export default function Settings() {
             </Select>
           </div>
 
-          {/* Save Button */}
+          {/* Global font size scaling */}
+          <style jsx global>{`
+            body[data-fontsize='regular'] {
+              font-size: 16px;
+            }
+            body[data-fontsize='large'] {
+              font-size: 18px;
+            }
+            body[data-fontsize='extra-large'] {
+              font-size: 20px;
+            }
+            body[data-fontsize='large'] h1,
+            body[data-fontsize='large'] h2,
+            body[data-fontsize='large'] input,
+            body[data-fontsize='large'] .ant-select-selector {
+              font-size: 2em !important;
+            }
+            body[data-fontsize='extra-large'] h1,
+            body[data-fontsize='extra-large'] h2,
+            body[data-fontsize='extra-large'] input,
+            body[data-fontsize='extra-large'] .ant-select-selector {
+              font-size: 2.5em !important;
+            }
+          `}</style>
+
           <Button type="primary" onClick={handleSave} style={styles.saveButton}>
             Save Changes
           </Button>
@@ -117,57 +207,4 @@ export default function Settings() {
       </div>
     </div>
   )
-}
-
-const styles: { [key: string]: React.CSSProperties } = {
-  page: {
-    minHeight: '100vh',
-    backgroundColor: '#F1F1EB',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: '40px'
-  },
-  card: {
-    backgroundColor: '#A0B6AA',
-    borderRadius: '2rem',
-    border: '3px solid',
-    padding: '40px',
-    width: '100%',
-    maxWidth: '480px',
-    boxShadow: '0 4px 12px rgba(0,0,0,0.1)'
-  },
-  backButton: {
-    marginBottom: '24px',
-    backgroundColor: '#203625',
-    color: 'white',
-    borderColor: '#203625',
-    borderRadius: '9999px'
-  },
-  header: {
-    textAlign: 'center',
-    fontSize: '24px',
-    marginBottom: '32px',
-    color: '#1D1E2C'
-  },
-  form: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '20px'
-  },
-  label: {
-    fontWeight: 'bold',
-    marginBottom: '4px'
-  },
-  input: {
-    width: '100%',
-    borderRadius: '12px'
-  },
-  saveButton: {
-    marginTop: '16px',
-    backgroundColor: '#203625',
-    color: 'white',
-    borderColor: '#203625',
-    borderRadius: '9999px'
-  }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,78 +1,65 @@
-/* Modified: Syed Rabbey (6/1/25) added new scroll wheel design */
+/* Modified: Syed Rabbey (6/1/25) - Added custom scrollbar, modal styling, and dark theme styles */
+/* Dark theme enhancements and animation accessibility by Mohammad Hoque (6/2/25) */
 
-/* Override Modal header */
+/* Modal Styling - Dark themed */
 .custom-modal .ant-modal-content {
   background-color: #252525 !important;
   border-radius: 8px;
 }
-
 .custom-modal .ant-modal-header {
   background-color: #252525 !important;
   border-bottom: 1px solid #4b5563 !important;
   border-radius: 8px 8px 0 0;
 }
-
 .custom-modal .ant-modal-close-x {
   color: #e0e0e0 !important;
 }
-
 .custom-modal .ant-modal-close-x:hover {
   color: #d1d5db !important;
 }
 
-/* Override Select dropdown */
+/* Select Styling - Dark themed dropdowns */
 .custom-select .ant-select-selector {
   background-color: #2f2f2f !important;
   border-color: #4b5563 !important;
   color: #e0e0e0 !important;
 }
-
 .custom-select .ant-select-arrow {
   color: #e0e0e0 !important;
 }
-
 .custom-select .ant-select-item-option {
   background-color: #2f2f2f !important;
   color: #e0e0e0 !important;
 }
-
 .custom-select .ant-select-item-option:hover {
   background-color: #3a3a3a !important;
 }
-
 .custom-select .ant-select-item-option-selected {
   background-color: #4b5563 !important;
 }
 
-/* Font size control for user settings */
-body[data-fontsize='regular'] {
-  font-size: 16px;
-}
+/* Font size control for theme settings (Mohammad Hoque) */
+body[data-fontsize='regular'] { font-size: 16px; }
+body[data-fontsize='large'] { font-size: 17px; }
+body[data-fontsize='extra-large'] { font-size: 18px; }
 
-body[data-fontsize='large'] {
-  font-size: 17px;
-}
-
-body[data-fontsize='extra-large'] {
-  font-size: 18px;
-}
-
-/* Fade-in animation */
+/* Animation - global fade in */
 @keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(20px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+  from { opacity: 0; transform: translateY(20px); }
+  to   { opacity: 1; transform: translateY(0); }
 }
-
 .fade-in {
   animation: fadeIn 1.5s ease-in-out;
 }
 
+/* Accessibility: reduce motion for users with preference (Mohammad Hoque) */
+@media (prefers-reduced-motion: reduce) {
+  .fade-in {
+    animation: none !important;
+  }
+}
+
+/* Footer default (light mode) */
 footer {
   background-color: #ffffff !important;
   color: #000000 !important;
@@ -81,32 +68,27 @@ footer {
   padding: 4px;
 }
 
-/* Sidebar */
+/* Sidebar styling */
 .sidebar-collapsed {
   width: 40px !important;
   min-width: 40px !important;
 }
-
 .hamburger-button {
   position: absolute !important;
   top: 16px;
   left: 12px;
   z-index: 1000;
 }
-
-/* Ensure the sidebar doesn't completely vanish */
 .sider {
   min-width: 40px;
   background-color: #9AB7A9 !important;
 }
-
-/* Sidebar button placement */
 .sidebar-bottom {
   margin-top: auto;
   padding-bottom: 16px;
 }
 
-/* Avatar styling */
+/* Avatar display */
 .meta.assistant .avatar img {
   width: 40px;
   height: 40px;
@@ -114,13 +96,12 @@ footer {
   object-fit: cover;
 }
 
-
+/* Send bar */
 .send-bar .button {
   background-color: #F1F1EA !important;
   border: none;
   color: #1e1e1e;
 }
-
 .send-bar .input {
   background-color: #F1F1EA !important;
   border: none;
@@ -129,34 +110,99 @@ footer {
   border-radius: 8px;
 }
 
-/* Custom simple Scrollbar */
+/* Scrollbar styling - Custom theme (Syed Rabbey) */
 ::-webkit-scrollbar {
   width: 6px;
   height: 6px;
 }
-
 ::-webkit-scrollbar-track {
   background: transparent;
 }
-
 ::-webkit-scrollbar-thumb {
-  background-color:#F1F1EA;
-
+  background-color: #F1F1EA;
   border-radius: 10px;
 }
-
 ::-webkit-scrollbar-thumb:hover {
   background-color: rgba(60, 60, 60, 0.5);
 }
-
-
 * {
   scrollbar-width: thin;
   scrollbar-color: rgba(60, 60, 60, 0.3) transparent;
 }
 
+/* Chat icon outline */
 .chat-icon-black-outline {
   color: black;
   stroke: black;
   stroke-width: 1.5;
+}
+
+/* ------------------ DARK THEME STYLES ------------------ */
+/* Added by: Mohammad Hoque - 06/02/25 */
+[data-theme='dark'] {
+  background-color: #0f0f17;
+  color: #F1F1EA;
+}
+
+[data-theme='dark'] .card,
+[data-theme='dark'] .container,
+[data-theme='dark'] .ant-card {
+  background-color: #0f0f17 !important;
+  border-color: #318182 !important;
+  color: #F1F1EA !important;
+}
+
+[data-theme='dark'] .ant-btn-primary {
+  background-color: #318182 !important;
+  border-color: #318182 !important;
+  color: #ffffff !important;
+}
+[data-theme='dark'] .ant-btn-primary:hover {
+  background-color: #256c6f !important;
+  border-color: #256c6f !important;
+}
+
+[data-theme='dark'] .ant-input,
+[data-theme='dark'] .ant-select-selector,
+[data-theme='dark'] .ant-picker {
+  background-color: #0f0f17 !important;
+  border-color: #318182 !important;
+  color: #F1F1EA !important;
+}
+
+[data-theme='dark'] .ant-input:focus,
+[data-theme='dark'] .ant-select-selector:focus,
+[data-theme='dark'] .ant-picker-focused {
+  border-color: #42a9aa !important;
+  box-shadow: 0 0 0 2px rgba(66, 169, 170, 0.3) !important;
+}
+
+[data-theme='dark'] .ant-select-item-option-selected {
+  background-color: #318182 !important;
+  color: #ffffff !important;
+}
+
+[data-theme='dark'] footer {
+  background-color: #0f0f17 !important;
+  color: #F1F1EA !important;
+}
+
+[data-theme='dark'] .sider {
+  background-color: #318182 !important;
+}
+
+[data-theme='dark'] ::-webkit-scrollbar-thumb {
+  background-color: #318182;
+}
+[data-theme='dark'] ::-webkit-scrollbar-thumb:hover {
+  background-color: #0f0f17;
+}
+
+[data-theme='dark'] * {
+  scrollbar-color: #318182 #0f0f17;
+}
+
+[data-theme='dark'] .chat-icon-black-outline {
+  color: #F1F1EA;
+  stroke: #F1F1EA;
 }


### PR DESCRIPTION
- Implemented dark theme and font size control from settings.tsx
- Synced user-selected theme and font size to <body> using data attributes
- Persisted user preferences via localStorage
- Applied stored preferences globally on initial app load (_app.tsx)
- Added corresponding global styles in globals.css for dark mode and font scaling
- Verified persistence across page reloads and navigation Note: Theme and font settings can only be modified from the Settings page