### PR TITLE
Potential fix for code scanning alert no. 62: Missing CSRF middleware

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -39,7 +39,8 @@
     "ollama": "^0.5.16",
     "pdf-parse": "^1.1.1",
     "tesseract.js": "^6.0.1",
-    "validator": "^13.15.15"
+    "validator": "^13.15.15",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.9"

--- a/backend/server.js
+++ b/backend/server.js
@@ -17,7 +17,7 @@
 
 import dotenv from 'dotenv';
 import path from 'path';
-
+import lusca from 'lusca';
 
 // Description: Set up the express app and connect to MongoDB
 const __filename = fileURLToPath(import.meta.url);
@@ -81,6 +81,7 @@ app.use(cors({
 app.use(express.json({ limit: '10mb' })); // Increase from default 100kb to 10mb
 app.use(express.urlencoded({ limit: '10mb', extended: true }));
 app.use(express.json());
+app.use(lusca.csrf()); // Add CSRF protection middleware
 //app.use('/api/auth', userLoginRoutes);
 app.use(logger);  // Logs all incoming requests
 


### PR DESCRIPTION
Potential fix for [https://github.com/violetyousif/Methuselah/security/code-scanning/62](https://github.com/violetyousif/Methuselah/security/code-scanning/62)

To fix the issue, we need to add CSRF protection middleware to the application. The `lusca` library is a well-known middleware package for CSRF protection in Express applications. We will:
1. Install the `lusca` package.
2. Import the `lusca` library in the `backend/server.js` file.
3. Add the `lusca.csrf()` middleware to the application, ensuring it is applied after the `cookieParser()` middleware and before any route definitions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
